### PR TITLE
Newell/cloudfront for https

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,13 +52,11 @@ jobs:
           name: Install deploy packages
           command: npm install
       - run:
-          name: Package
-          command: ruby serverless.rb package dev false
+          name: Create Domain
+          command: ruby serverless.rb create_domain dev false
       - run:
           name: Deploy
-          command: |
-            sls create_domain --stage dev -v
-            sls deploy --stage dev -v
+          command: sls deploy --stage dev -v
 
   deploy-prod:
     <<: *defaults
@@ -79,12 +77,10 @@ jobs:
           command: npm install
       - run:
           name: Package
-          command: ruby serverless.rb package prod false
+          command: ruby serverless.rb create_domain prod false
       - run:
           name: Deploy
-          command: |
-            sls create_domain --stage prod -v
-            sls deploy --stage prod -v
+          command: sls deploy --stage prod -v
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,9 @@ jobs:
           command: ruby serverless.rb package dev false
       - run:
           name: Deploy
-          command: sls deploy --stage dev -v
+          command: |
+            sls create_domain --stage dev -v
+            sls deploy --stage dev -v
 
   deploy-prod:
     <<: *defaults
@@ -80,7 +82,9 @@ jobs:
           command: ruby serverless.rb package prod false
       - run:
           name: Deploy
-          command: sls deploy --stage prod -v
+          command: |
+            sls create_domain --stage prod -v
+            sls deploy --stage prod -v
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,12 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              only:
+                - develop
+                - master
       - test
       - deploy-dev:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,6 @@ workflows:
             branches:
               only:
                 - develop
-                - newell/cloudfront_for_https
       - deploy-prod:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,11 @@ jobs:
           name: Install deploy packages
           command: npm install
       - run:
+          name: Package
+          command: ruby serverless.rb package dev false
+      - run:
           name: Deploy
-          command: |
-            ruby serverless.rb deploy dev false
+          command: sls deploy --stage dev -v
 
   deploy-prod:
     <<: *defaults
@@ -74,9 +76,11 @@ jobs:
           name: Install deploy packages
           command: npm install
       - run:
+          name: Package
+          command: ruby serverless.rb package prod false
+      - run:
           name: Deploy
-          command: |
-            ruby serverless.rb deploy prod false
+          command: sls deploy --stage prod -v
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,12 +87,11 @@ workflows:
   commit:
     jobs:
       - build
-      - test:
-          requires:
-            - build
+      - test
       - deploy-dev:
           requires:
             - test
+            - build
           filters:
             branches:
               only:
@@ -101,6 +100,7 @@ workflows:
       - deploy-prod:
           requires:
             - test
+            - build
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ jobs:
       - run:
           name: Deploy
           command: |
-            ruby serverless.rb create_domain dev false && \
             ruby serverless.rb deploy dev false
 
   deploy-prod:
@@ -77,7 +76,6 @@ jobs:
       - run:
           name: Deploy
           command: |
-            ruby serverless.rb create_domain prod false && \
             ruby serverless.rb deploy prod false
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ workflows:
             branches:
               only:
                 - develop
+                - newell/cloudfront_for_https
       - deploy-prod:
           requires:
             - test

--- a/lambda/lib/file-builder.js
+++ b/lambda/lib/file-builder.js
@@ -4,12 +4,11 @@ const Base64Handler = require('./base64-handler');
 const _ = require('lodash');
 const md5 = require('md5');
 const BadRequest = require('./bad-request');
-const util = require('util');
 
 module.exports = class FileBuilder {
     constructor(base64Handler, cacheControl) {
         this.base64Handler = _.isUndefined(base64Handler) ? Base64Handler : base64Handler;
-        this.cacheControl = _.isUndefined(cacheControl) ? 'max-age=186400' : cacheControl;
+        this.cacheControl = _.isUndefined(cacheControl) ? 'max-age=86400' : cacheControl;
     }
 
     getFile(parsedRequest, callback) {

--- a/lambda/lib/moderator.js
+++ b/lambda/lib/moderator.js
@@ -29,7 +29,7 @@ module.exports = class Moderator {
             .then(result => {
                 console.log('The rekognition result:', util.inspect(result, {depth: 5}));
                 if (result.ModerationLabels.length > 0) {
-                    callback(new ModerationThresholdExceeded(result));
+                    callback(new ModerationThresholdExceeded(JSON.stringify(result)));
                 }
                 callback(undefined, event);
             })

--- a/lambda/lib/pinster-api-client.js
+++ b/lambda/lib/pinster-api-client.js
@@ -39,7 +39,7 @@ module.exports = class PinsterApiClient {
                         callback(undefined, response, body);
                     }
                     else {
-                        callback(`Api call failed due to non good status. ${response}, ${body}`);
+                        callback(`Api call failed due to non good status. ${JSON.stringify(response)}, ${body}`);
                     }
                 }
             });

--- a/lambda/test/file-builder.js
+++ b/lambda/test/file-builder.js
@@ -16,10 +16,10 @@ describe('FileBuilder', function () {
             Key: 'raw/' + imageMD5,
             Body: Buffer.from(base64Image, 'base64'),
             ContentType: 'image/png',
-            CacheControl: 'max-age=186400',
+            CacheControl: 'max-age=86400',
             Metadata: {
                 'metadata': 'value',
-                "base_file_name": "7f7af91e3a7e514a09b3ad0e364ba3ce"
+                'base_file_name': '7f7af91e3a7e514a09b3ad0e364ba3ce'
             },
             Bucket: 'bucket'
         };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/PinsterTeam/ImageService#readme",
   "devDependencies": {
+    "serverless-domain-manager": "^2.3.6",
     "serverless-plugin-log-retention": "^1.0.3",
     "serverless-pseudo-parameters": "^1.4.2",
     "serverless-step-functions": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/PinsterTeam/ImageService#readme",
   "devDependencies": {
-    "serverless-domain-manager": "^2.3.6",
     "serverless-plugin-log-retention": "^1.0.3",
     "serverless-pseudo-parameters": "^1.4.2",
     "serverless-step-functions": "^1.3.0"

--- a/serverless.rb
+++ b/serverless.rb
@@ -30,18 +30,14 @@ puts "\nBuilding serverless.yml from serverless_template.yml with correct bucket
 
 serverless_file = File.read('serverless_template.yml')
 
-if ['deploy', 'package'].include?(serverless_command)
-  puts "Doing what fucking serverless can't figure out. Getting secret for auth token"
+puts "Doing what fucking serverless can't figure out. Getting secret for auth token"
 
-  client = Aws::SecretsManager::Client.new(region: 'us-east-1')
+client = Aws::SecretsManager::Client.new(region: 'us-east-1')
 
-  secret_response = client.get_secret_value({ secret_id: "image-service-#{stage}", version_stage: 'AWSCURRENT' })
-  token = JSON.parse(secret_response.secret_string)['create-image-token']
+secret_response = client.get_secret_value(secret_id: "image-service-#{stage}", version_stage: 'AWSCURRENT')
+token = JSON.parse(secret_response.secret_string)['create-image-token']
 
-  serverless_file.gsub!('AUTH_TOKEN_CHANGE_ME', token)
-else
-  puts "Not grabbing AUTH_TOKEN from secret manager because we weren't run with 'deploy' or 'package'"
-end
+serverless_file.gsub!('AUTH_TOKEN_CHANGE_ME', token)
 
 serverless = YAML.load(serverless_file)
 bucket_name = serverless['custom']['imageUploadBucket']

--- a/serverless.rb
+++ b/serverless.rb
@@ -44,48 +44,6 @@ else
 end
 
 serverless = YAML.load(serverless_file)
-bucket_name = serverless['custom']['imageUploaderBucket']
-
-unless bucket_name
-  puts "\n\nFailed to find the uploader bucket in the serverless_template.yml file.\n\n"
-  return
-end
-
-puts "Found Bucket name: #{bucket_name}"
-
-supported_stages.each { |supported_stage| bucket_name.gsub!(/-?#{supported_stage}\Z/, '') }
-
-# puts "Trimmed bucket name to not include stage suffix: #{bucket_name}"
-
-s3_name = 'S3Bucket' + bucket_name.gsub('${self:provider.stage}', stage).gsub(/[-.]/, '').capitalize
-s3_name_no_env = 'S3Bucket' + bucket_name.gsub('${self:provider.stage}', '').gsub(/[-.]/, '').capitalize
-
-puts "Looking for resource name starting with: #{s3_name} or #{s3_name_no_env}"
-
-# puts "Looking through keys: #{serverless['resources']['Resources'].keys}"
-found_keys = serverless['resources']['Resources'].keys.select { |key| /#{s3_name}.*/.match(key) }
-found_keys += serverless['resources']['Resources'].keys.select { |key| /#{s3_name_no_env}.*/.match(key) }
-
-if found_keys.size > 1
-  puts "\n\nFound more than one possible bucket name. Not sure what to do: #{found_keys}\n\n"
-  return
-end
-
-if found_keys.size < 1
-  puts "\nFailed to find a resource matching: \"#{s3_name}\". Found Keys: #{found_keys}\n\n"
-  return
-end
-
-new_bucket_name = bucket_name.gsub('${self:provider.stage}', stage)
-
-puts "New bucket name: #{new_bucket_name}"
-serverless['custom']['imageUploaderBucket'] = new_bucket_name
-
-new_s3_name = 'S3Bucket' + bucket_name.gsub('${self:provider.stage}', stage).gsub(/[-.]/, '').capitalize
-
-puts "New s3 resource name: #{new_s3_name}"
-serverless['resources']['Resources'][new_s3_name] = serverless['resources']['Resources'].delete(found_keys.first)
-
 
 unless use_aws_credentials_file
   serverless['provider'].delete('profile')

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -180,7 +180,7 @@ resources:
       Type: 'AWS::S3::Bucket'
       Properties:
         BucketName: ${self:custom.imageUploadBucket}
-        AccessControl: PublicWrite
+        AccessControl: PublicReadWrite
         CorsConfiguration:
           CorsRules:
             - AllowedHeaders: ['*']

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -52,12 +52,12 @@ provider:
 custom:
   logRetentionInDays: 14
   defaultStage: dev
-  customDomain:
-    domainName: ${self:custom.imageUploaderBucket}
-    basePath: ''
-    stage: ${self:provider.stage}
-    createRoute53Record: true
-    certificateName: image-service-dev.pinster.io
+#  customDomain:
+#    domainName: ${self:custom.imageUploaderBucket}
+#    basePath: ''
+#    stage: ${self:provider.stage}
+#    createRoute53Record: true
+#    certificateName: image-service-dev.pinster.io
   failure_notification_sns: ImageServiceFailureSNS${self:provider.stage}
   failure_notification_sns_arn:
     Fn::Join:
@@ -187,7 +187,7 @@ resources:
                 IndexDocument: index.html
                 RoutingRules:
                 - RedirectRule:
-                    HostName: ${self:custom.customDomain.domainName}
+                    HostName: "${self:custom.imageUploaderBucket}"
                     HttpRedirectCode: 307
                     Protocol: https
                     ReplaceKeyPrefixWith: images/generate?key=
@@ -208,7 +208,7 @@ resources:
     WebsiteCloudfront:
       Type: AWS::CloudFront::Distribution
       DependsOn:
-        - ${self:custom.imageUploaderBucket}
+        - S3BucketImageservice${self:provider.stage}pinsterio
       Properties:
         DistributionConfig:
           Aliases:
@@ -239,19 +239,19 @@ resources:
           ViewerCertificate:
             AcmCertificateArn: arn:aws:acm:us-east-1:582149114309:certificate/4527b2fc-14a6-417c-a35c-82f5426e516a
             SslSupportMethod: sni-only
-
-    WebsiteDNSName:
-      Type: AWS::Route53::RecordSetGroup
-      Properties:
-        HostedZoneName: pinster.io.
-        RecordSets:
-        - Name: "${self:custom.imageUploaderBucket}"
-          Type: CNAME
-          TTL: 900
-          ResourceRecords:
-            - Fn::GetAtt:
-              - WebsiteCloudfront
-              - DomainName
+#
+#    WebsiteDNSName:
+#      Type: AWS::Route53::RecordSetGroup
+#      Properties:
+#        HostedZoneName: pinster.io.
+#        RecordSets:
+#        - Name: "${self:custom.imageUploaderBucket}"
+#          Type: CNAME
+#          TTL: 900
+#          ResourceRecords:
+#            - Fn::GetAtt:
+#              - WebsiteCloudfront
+#              - DomainName
     ImageServiceFailureSNS:
       Type: "AWS::SNS::Topic"
       Properties:
@@ -259,5 +259,4 @@ resources:
 plugins:
   - serverless-step-functions
   - serverless-pseudo-parameters
-  - serverless-domain-manager
   - serverless-plugin-log-retention

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -17,9 +17,12 @@ provider:
       - lambda/test
       - node_modules
       - "*.md"
+      - "*.rb"
+      - Gemfile
+      - Gemfile.lock
+      - .eslintrc.json
 
   iamRoleStatements:
-
     - Effect: 'Allow'
       Action:
         - "sns:Publish"
@@ -54,12 +57,12 @@ provider:
 custom:
   logRetentionInDays: 14
   defaultStage: dev
-#  customDomain:
-#    domainName: ${self:custom.imageHostBucket}
-#    basePath: ''
-#    stage: ${self:provider.stage}
-#    createRoute53Record: true
-#    certificateName: image-service-dev.pinster.io
+  customDomain:
+    domainName: images.${self:custom.imageHostBucket}
+    basePath: ''
+    stage: ${self:provider.stage}
+    createRoute53Record: true
+    certificateName: image-service-dev.pinster.io
   failure_notification_sns: ImageServiceFailureSNS${self:provider.stage}
   failure_notification_sns_arn:
     Fn::Join:
@@ -82,7 +85,6 @@ functions:
     events:
       - http:
           method: post
-          path: images
           cors: true
     memorySize: 1024
     environment:
@@ -105,7 +107,7 @@ functions:
     events:
       - http:
           method: get
-          path: images/generate
+          path: generate
           cors: true
     memorySize: 1024
     environment:
@@ -184,10 +186,10 @@ resources:
                 IndexDocument: index.html
                 RoutingRules:
                 - RedirectRule:
-                    HostName: "${self:custom.imageHostBucket}"
+                    HostName: ${self:custom.customDomain.domainName}
                     HttpRedirectCode: 307
                     Protocol: https
-                    ReplaceKeyPrefixWith: images/generate?key=
+                    ReplaceKeyPrefixWith: generate?key=
                   RoutingRuleCondition:
                     HttpErrorCodeReturnedEquals: 404
     ImageHostCloudfront:
@@ -244,4 +246,5 @@ resources:
 plugins:
   - serverless-step-functions
   - serverless-pseudo-parameters
+  - serverless-domain-manager
   - serverless-plugin-log-retention

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -62,7 +62,7 @@ custom:
     basePath: ''
     stage: ${self:provider.stage}
     createRoute53Record: true
-    certificateName: image-service-dev.pinster.io
+    certificateName: images.image-service-dev.pinster.io
   failure_notification_sns: ImageServiceFailureSNS${self:provider.stage}
   failure_notification_sns_arn:
     Fn::Join:

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -75,7 +75,7 @@ custom:
         - Ref: AWS::AccountId
         - ${self:custom.failure_notification_sns}
   imageHostBucket: image-service-${self:provider.stage}.pinster.io
-  imageBucketUrl: https://${self:custom.imageHostBucket}
+  imageHostBucketUrl: https://${self:custom.imageHostBucket}
   imageUploadBucket: image-service-upload-${self:provider.stage}.pinster.io
   thumbnailProcessorName: thumbnail-processor-${self:provider.stage}
   pinsterApiUrl: https://api-${self:provider.stage}.pinster.io
@@ -114,7 +114,7 @@ functions:
     memorySize: 1024
     environment:
           BUCKET: ${self:custom.imageHostBucket}
-          URL: ${self:custom.imageBucketUrl}
+          URL: ${self:custom.imageHostBucketUrl}
 
   moderate:
     handler: lambda/lambda.moderate
@@ -126,7 +126,7 @@ functions:
     environment:
         BUCKET: ${self:custom.imageHostBucket}
         PREFIX: ""
-        URL: ${self:custom.imageBucketUrl}
+        URL: ${self:custom.imageHostBucketUrl}
 
   notifySuccess:
     handler: lambda/lambda.notifySuccess
@@ -260,6 +260,7 @@ resources:
               - GET
               - HEAD
             Compress: true
+            DefaultTTL: 0
             TargetOriginId: S3Origin
             ForwardedValues:
               QueryString: true

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -187,6 +187,19 @@ resources:
               AllowedMethods: [PUT, POST]
               AllowedOrigins: ['*']
               MaxAge: '3600'
+    S3BucketPermissions:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket: ${self:custom.imageUploadBucket}
+        PolicyDocument:
+          Statement:
+            - Principal: "*"
+              Action:
+                - s3:GetObject
+                - s3:PutObject
+              Effect: Allow
+              Sid: "AddPerm"
+              Resource: arn:aws:s3:::${self:custom.imageUploadBucket}/*
 
     ImageHostBucket:
       Type: 'AWS::S3::Bucket'

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -188,7 +188,7 @@ resources:
               AllowedMethods: [PUT, POST]
               AllowedOrigins: ['*']
               MaxAge: '3600'
-    S3BucketPermissions:
+    S3BucketPermissionsImageUpload:
       Type: AWS::S3::BucketPolicy
       Properties:
         Bucket: ${self:custom.imageUploadBucket}
@@ -196,7 +196,6 @@ resources:
           Statement:
             - Principal: "*"
               Action:
-                - s3:GetObject
                 - s3:PutObject
               Effect: Allow
               Sid: "AddPerm"
@@ -206,7 +205,7 @@ resources:
       Type: 'AWS::S3::Bucket'
       Properties:
         BucketName: ${self:custom.imageHostBucket}
-        AccessControl: PublicRead
+        AccessControl: PublicReadWrite
         CorsConfiguration:
           CorsRules:
             - AllowedHeaders: ['*']
@@ -223,6 +222,20 @@ resources:
                     ReplaceKeyPrefixWith: generate?key=
                   RoutingRuleCondition:
                     HttpErrorCodeReturnedEquals: 404
+    S3BucketPermissionsImageHost:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket: ${self:custom.imageHostBucket}
+        PolicyDocument:
+          Statement:
+            - Principal: "*"
+              Action:
+                - s3:GetObject
+                - s3:PutObject
+              Effect: Allow
+              Sid: "AddPerm"
+              Resource: arn:aws:s3:::${self:custom.imageHostBucket}/*
+
     ImageHostCloudfront:
       Type: AWS::CloudFront::Distribution
       DependsOn:

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -251,7 +251,7 @@ resources:
               CustomOriginConfig:
                 HTTPPort: '80'
                 HTTPSPort: '443'
-                OriginProtocolPolicy: http-only
+                OriginProtocolPolicy: https-only
           Enabled: true
           HttpVersion: 'http2'
           DefaultRootObject: index.html

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -59,10 +59,11 @@ custom:
   defaultStage: dev
   customDomain:
     domainName: images.image-service-${self:provider.stage}.pinster.io
-    basePath: ''
+    basePath: '/'
     stage: ${self:provider.stage}
     createRoute53Record: true
     certificateName: images.image-service-dev.pinster.io # This is the name of the cert, it covers prod too.
+    endpointType: 'regional'
   failure_notification_sns: ImageServiceFailureSNS${self:provider.stage}
   failure_notification_sns_arn:
     Fn::Join:

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -30,8 +30,9 @@ provider:
       Action:
         - "s3:*"
       Resource:
-        - "arn:aws:s3:::${self:custom.imageUploaderBucket}/*"
-
+        - "arn:aws:s3:::${self:custom.imageHostBucket}/*"
+        - "arn:aws:s3:::${self:custom.imageUploadBucket}/*"
+        
     - Effect: "Allow"
       Action:
         - "states:StartExecution"
@@ -48,12 +49,13 @@ provider:
       Action:
         - "lambda:InvokeFunction"
       Resource:
-        - "arn:aws:lambda:::${self:custom.imageUploaderBucket}/*"
+        - "arn:aws:lambda:::${self:custom.imageUploadBucket}/*"
+
 custom:
   logRetentionInDays: 14
   defaultStage: dev
 #  customDomain:
-#    domainName: ${self:custom.imageUploaderBucket}
+#    domainName: ${self:custom.imageHostBucket}
 #    basePath: ''
 #    stage: ${self:provider.stage}
 #    createRoute53Record: true
@@ -68,13 +70,9 @@ custom:
         - Ref: AWS::Region
         - Ref: AWS::AccountId
         - ${self:custom.failure_notification_sns}
-
-  # if the bucket name is changed then you must go to the resources section and change it there too!
-  # This is a stupid limitation of serverless
-  # https://github.com/serverless/serverless/issues/2486
-  # https://github.com/serverless/serverless/issues/2749
-  imageUploaderBucket: image-service-${self:provider.stage}.pinster.io
-  imageBucketUrl: https://${self:custom.imageUploaderBucket}
+  imageHostBucket: image-service-${self:provider.stage}.pinster.io
+  imageBucketUrl: https://${self:custom.imageHostBucket}
+  imageUploadBucket: image-service-upload-${self:provider.stage}.pinster.io
   thumbnailProcessorName: thumbnail-processor-${self:provider.stage}
   pinsterApiUrl: https://api-${self:provider.stage}.pinster.io
 
@@ -88,13 +86,13 @@ functions:
           cors: true
     memorySize: 1024
     environment:
-          BUCKET_NAME: ${self:custom.imageUploaderBucket}
+          BUCKET_NAME: ${self:custom.imageUploadBucket}
 
   startExecution:
     handler: lambda/lambda.startExecution
     events:
       - s3:
-          bucket: ${self:custom.imageUploaderBucket}
+          bucket: ${self:custom.imageUploadBucket}
           event: s3:ObjectCreated:*
           rules:
             - prefix: raw/
@@ -111,7 +109,7 @@ functions:
           cors: true
     memorySize: 1024
     environment:
-          BUCKET: ${self:custom.imageUploaderBucket}
+          BUCKET: ${self:custom.imageHostBucket}
           URL: ${self:custom.imageBucketUrl}
 
   moderate:
@@ -122,7 +120,7 @@ functions:
     handler: lambda/lambda.moveImage
     memorySize: 512
     environment:
-        BUCKET: ${self:custom.imageUploaderBucket}
+        BUCKET: ${self:custom.imageHostBucket}
         PREFIX: ""
         URL: ${self:custom.imageBucketUrl}
 
@@ -171,12 +169,11 @@ stepFunctions:
 
 resources:
   Resources:
-  # if the bucket name is changed then this resource name must be changed! This is a stupid limitation of serverless
-  # https://github.com/serverless/serverless/issues/2486
-  # https://github.com/serverless/serverless/issues/2749
-    S3BucketImageservicepinsterio:
+    ImageHostBucket:
       Type: 'AWS::S3::Bucket'
       Properties:
+        BucketName: ${self:custom.imageHostBucket}
+        AccessControl: PublicRead
         CorsConfiguration:
           CorsRules:
             - AllowedHeaders: ['*']
@@ -187,35 +184,23 @@ resources:
                 IndexDocument: index.html
                 RoutingRules:
                 - RedirectRule:
-                    HostName: "${self:custom.imageUploaderBucket}"
+                    HostName: "${self:custom.imageHostBucket}"
                     HttpRedirectCode: 307
                     Protocol: https
                     ReplaceKeyPrefixWith: images/generate?key=
                   RoutingRuleCondition:
                     HttpErrorCodeReturnedEquals: 404
-    S3BucketPermissions:
-      Type: AWS::S3::BucketPolicy
-      Properties:
-        Bucket: ${self:custom.imageUploaderBucket}
-        PolicyDocument:
-          Statement:
-            - Principal: "*"
-              Action:
-                - s3:GetObject
-              Effect: Allow
-              Sid: "AddPerm"
-              Resource: arn:aws:s3:::${self:custom.imageUploaderBucket}/*
-    WebsiteCloudfront:
+    ImageHostCloudfront:
       Type: AWS::CloudFront::Distribution
       DependsOn:
-        - S3BucketImageservice${self:provider.stage}pinsterio
+        - ImageHostBucket
       Properties:
         DistributionConfig:
           Aliases:
-            - ${self:custom.imageUploaderBucket}
+            - ${self:custom.imageHostBucket}
           Comment: Cloudfront Distribution pointing to S3 bucket
           Origins:
-            - DomainName: "${self:custom.imageUploaderBucket}.s3.amazonaws.com"
+            - DomainName: "${self:custom.imageHostBucket}.s3.amazonaws.com"
               Id: S3Origin
               CustomOriginConfig:
                 HTTPPort: '80'
@@ -239,19 +224,19 @@ resources:
           ViewerCertificate:
             AcmCertificateArn: arn:aws:acm:us-east-1:582149114309:certificate/4527b2fc-14a6-417c-a35c-82f5426e516a
             SslSupportMethod: sni-only
-#
-#    WebsiteDNSName:
-#      Type: AWS::Route53::RecordSetGroup
-#      Properties:
-#        HostedZoneName: pinster.io.
-#        RecordSets:
-#        - Name: "${self:custom.imageUploaderBucket}"
-#          Type: CNAME
-#          TTL: 900
-#          ResourceRecords:
-#            - Fn::GetAtt:
-#              - WebsiteCloudfront
-#              - DomainName
+
+    ImageHostDNSName:
+      Type: AWS::Route53::RecordSetGroup
+      Properties:
+        HostedZoneName: pinster.io.
+        RecordSets:
+        - Name: "${self:custom.imageHostBucket}"
+          Type: CNAME
+          TTL: 900
+          ResourceRecords:
+            - Fn::GetAtt:
+              - WebsiteCloudfront
+              - DomainName
     ImageServiceFailureSNS:
       Type: "AWS::SNS::Topic"
       Properties:

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -86,7 +86,7 @@ functions:
       - http:
           method: post
           cors: true
-          path: create
+          path: /
     memorySize: 1024
     environment:
           BUCKET_NAME: ${self:custom.imageUploadBucket}

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -53,7 +53,7 @@ custom:
   logRetentionInDays: 14
   defaultStage: dev
   customDomain:
-    domainName: image-service-${self:provider.stage}.pinster.io
+    domainName: ${self:custom.imageUploaderBucket}
     basePath: ''
     stage: ${self:provider.stage}
     createRoute53Record: true
@@ -68,13 +68,13 @@ custom:
         - Ref: AWS::Region
         - Ref: AWS::AccountId
         - ${self:custom.failure_notification_sns}
-  imageBucketUrl: http://pinster-image-service-${self:provider.stage}.s3-website-#{AWS::Region}.amazonaws.com
 
   # if the bucket name is changed then you must go to the resources section and change it there too!
   # This is a stupid limitation of serverless
   # https://github.com/serverless/serverless/issues/2486
   # https://github.com/serverless/serverless/issues/2749
-  imageUploaderBucket: pinster-image-service
+  imageUploaderBucket: image-service-${self:provider.stage}.pinster.io
+  imageBucketUrl: https://${self:custom.imageUploaderBucket}
   thumbnailProcessorName: thumbnail-processor-${self:provider.stage}
   pinsterApiUrl: https://api-${self:provider.stage}.pinster.io
 
@@ -174,7 +174,7 @@ resources:
   # if the bucket name is changed then this resource name must be changed! This is a stupid limitation of serverless
   # https://github.com/serverless/serverless/issues/2486
   # https://github.com/serverless/serverless/issues/2749
-    S3BucketPinsterimageservice:
+    S3BucketImageservicepinsterio:
       Type: 'AWS::S3::Bucket'
       Properties:
         CorsConfiguration:
@@ -205,6 +205,53 @@ resources:
               Effect: Allow
               Sid: "AddPerm"
               Resource: arn:aws:s3:::${self:custom.imageUploaderBucket}/*
+    WebsiteCloudfront:
+      Type: AWS::CloudFront::Distribution
+      DependsOn:
+        - ${self:custom.imageUploaderBucket}
+      Properties:
+        DistributionConfig:
+          Aliases:
+            - ${self:custom.imageUploaderBucket}
+          Comment: Cloudfront Distribution pointing to S3 bucket
+          Origins:
+            - DomainName: "${self:custom.imageUploaderBucket}.s3.amazonaws.com"
+              Id: S3Origin
+              CustomOriginConfig:
+                HTTPPort: '80'
+                HTTPSPort: '443'
+                OriginProtocolPolicy: http-only
+          Enabled: true
+          HttpVersion: 'http2'
+          DefaultRootObject: index.html
+          DefaultCacheBehavior:
+            AllowedMethods:
+              - GET
+              - HEAD
+            Compress: true
+            TargetOriginId: S3Origin
+            ForwardedValues:
+              QueryString: true
+              Cookies:
+                Forward: none
+            ViewerProtocolPolicy: redirect-to-https
+          PriceClass: PriceClass_100
+          ViewerCertificate:
+            AcmCertificateArn: arn:aws:acm:us-east-1:582149114309:certificate/4527b2fc-14a6-417c-a35c-82f5426e516a
+            SslSupportMethod: sni-only
+
+    WebsiteDNSName:
+      Type: AWS::Route53::RecordSetGroup
+      Properties:
+        HostedZoneName: pinster.io.
+        RecordSets:
+        - Name: "${self:custom.imageUploaderBucket}"
+          Type: CNAME
+          TTL: 900
+          ResourceRecords:
+            - Fn::GetAtt:
+              - WebsiteCloudfront
+              - DomainName
     ImageServiceFailureSNS:
       Type: "AWS::SNS::Topic"
       Properties:

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -86,6 +86,7 @@ functions:
       - http:
           method: post
           cors: true
+          path: /
     memorySize: 1024
     environment:
           BUCKET_NAME: ${self:custom.imageUploadBucket}

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -235,7 +235,7 @@ resources:
           TTL: 900
           ResourceRecords:
             - Fn::GetAtt:
-              - WebsiteCloudfront
+              - ImageHostCloudfront
               - DomainName
     ImageServiceFailureSNS:
       Type: "AWS::SNS::Topic"

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -58,11 +58,11 @@ custom:
   logRetentionInDays: 14
   defaultStage: dev
   customDomain:
-    domainName: images.${self:custom.imageHostBucket}
+    domainName: images.image-service-${self:provider.stage}.pinster.io
     basePath: ''
     stage: ${self:provider.stage}
     createRoute53Record: true
-    certificateName: images.image-service-dev.pinster.io
+    certificateName: images.image-service-dev.pinster.io # This is the name of the cert, it covers prod too.
   failure_notification_sns: ImageServiceFailureSNS${self:provider.stage}
   failure_notification_sns_arn:
     Fn::Join:
@@ -86,7 +86,7 @@ functions:
       - http:
           method: post
           cors: true
-          path: /
+          path: create
     memorySize: 1024
     environment:
           BUCKET_NAME: ${self:custom.imageUploadBucket}

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -172,6 +172,22 @@ stepFunctions:
 
 resources:
   Resources:
+  # if the bucket name is changed then this resource name must be changed! This is a stupid limitation of serverless
+  # This is handled by serverless.rb
+  # https://github.com/serverless/serverless/issues/2486
+  # https://github.com/serverless/serverless/issues/2749
+    S3BucketImageserviceuploadpinsterio:
+      Type: 'AWS::S3::Bucket'
+      Properties:
+        BucketName: ${self:custom.imageUploadBucket}
+        AccessControl: PublicWrite
+        CorsConfiguration:
+          CorsRules:
+            - AllowedHeaders: ['*']
+              AllowedMethods: [PUT, POST]
+              AllowedOrigins: ['*']
+              MaxAge: '3600'
+
     ImageHostBucket:
       Type: 'AWS::S3::Bucket'
       Properties:
@@ -180,7 +196,7 @@ resources:
         CorsConfiguration:
           CorsRules:
             - AllowedHeaders: ['*']
-              AllowedMethods: [GET, PUT, POST, HEAD]
+              AllowedMethods: [GET, PUT, HEAD]
               AllowedOrigins: ['*']
               MaxAge: '3600'
         WebsiteConfiguration:

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -260,6 +260,9 @@ resources:
               - GET
               - HEAD
             Compress: true
+            #This prevents CloudFront from caching our 307 redirect when we need to create a thumbnail on the fly.
+            #This also means that any item we want to serve from CloudFront MUST have a Cache-Control header set.
+            #Otherwise CloudFront will not cache anything.
             DefaultTTL: 0
             TargetOriginId: S3Origin
             ForwardedValues:

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -244,7 +244,7 @@ resources:
         DistributionConfig:
           Aliases:
             - ${self:custom.imageHostBucket}
-          Comment: Cloudfront Distribution pointing to S3 bucket
+          Comment: "Image hosting for ${self:provider.stage}"
           Origins:
             - DomainName: "${self:custom.imageHostBucket}.s3-website-us-east-1.amazonaws.com"
               Id: S3Origin

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -59,7 +59,7 @@ custom:
   defaultStage: dev
   customDomain:
     domainName: images.image-service-${self:provider.stage}.pinster.io
-    basePath: '/'
+    basePath: '(none)'
     stage: ${self:provider.stage}
     createRoute53Record: true
     certificateName: images.image-service-dev.pinster.io # This is the name of the cert, it covers prod too.

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -251,7 +251,7 @@ resources:
               CustomOriginConfig:
                 HTTPPort: '80'
                 HTTPSPort: '443'
-                OriginProtocolPolicy: https-only
+                OriginProtocolPolicy: http-only
           Enabled: true
           HttpVersion: 'http2'
           DefaultRootObject: index.html

--- a/serverless_template.yml
+++ b/serverless_template.yml
@@ -246,7 +246,7 @@ resources:
             - ${self:custom.imageHostBucket}
           Comment: Cloudfront Distribution pointing to S3 bucket
           Origins:
-            - DomainName: "${self:custom.imageHostBucket}.s3.amazonaws.com"
+            - DomainName: "${self:custom.imageHostBucket}.s3-website-us-east-1.amazonaws.com"
               Id: S3Origin
               CustomOriginConfig:
                 HTTPPort: '80'


### PR DESCRIPTION
Basically I had to split it into two buckets and then manually make a CloudFront distribution for us. I've got it working in dev, but the caveat with prod is that we already have a bunch of images and those will have to be moved to the new bucket before these changes go live. And I'll have to make sure to keep all of those images' metadata in the move because that's really important now. 
Oh, and I'll have to be sure to update all the images in the database to https so that our clients can see images after they're migrated. (this is going to be a one-time migration) 

The other caveat is that in order to go live I have to destroy the current "hidden" CloudFront distribution for production and delete the CNAME for that distribution in order to allow us to create a new one. a.k.a. downtime

But we get https for our images now
:tada: 